### PR TITLE
Label DeployDB-triggered builds as such by showing a badge in the UI.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/deploydb/DeployDbCause.java
+++ b/src/main/java/org/jenkinsci/plugins/deploydb/DeployDbCause.java
@@ -1,0 +1,13 @@
+package org.jenkinsci.plugins.deploydb;
+
+import hudson.model.Cause;
+
+public class DeployDbCause extends Cause {
+
+    @Override
+    public String getShortDescription() {
+        // Text shown in the badge on the build page
+        return Messages.Cause();
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/deploydb/TriggerEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/deploydb/TriggerEndpoint.java
@@ -52,8 +52,8 @@ public class TriggerEndpoint implements UnprotectedRootAction {
 
         // Schedule a build for each of the jobs that matched
         for (AbstractProject<?, ?> job : jobs) {
-            // TODO: Build cause and action
-            job.scheduleBuild2(0);
+            // TODO: Build action
+            job.scheduleBuild2(0, new DeployDbCause());
         }
 
         // Respond with success in all cases

--- a/src/main/resources/org/jenkinsci/plugins/deploydb/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploydb/Messages.properties
@@ -1,3 +1,4 @@
 TriggerDisplayName=DeployDB webhook trigger
 TriggerInvalidRegex=Invalid regular expression
 TriggeredBuilds=Triggered {0} builds
+Cause=Started by a DeployDB webhook

--- a/src/test/java/org/jenkinsci/plugins/deploydb/TriggerEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/deploydb/TriggerEndpointTest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.deploydb;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.WebRequestSettings;
 import com.gargoylesoftware.htmlunit.WebResponse;
+import hudson.Util;
 import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import jenkins.model.Jenkins;
@@ -95,6 +96,10 @@ public class TriggerEndpointTest {
 
         // Then a build of that job should have been scheduled
         assertJobsTriggered(response, jobA);
+
+        // And DeployDB should be attributed as the cause
+        Queue.Item build = jenkins.getInstance().getQueue().getItem(jobA);
+        assertEquals(1, Util.filter(build.getCauses(), DeployDbCause.class).size());
     }
 
     @Test public void hookShouldTriggerMultipleMatchingJobs() throws Exception {


### PR DESCRIPTION
**Started via a webhook:**
![image](https://cloud.githubusercontent.com/assets/138615/6741247/356c31e4-ce43-11e4-9ccc-f57ee599ff0b.png)

**As opposed to manually clicking Build Now:**
![image](https://cloud.githubusercontent.com/assets/138615/6741318/b4e1ea72-ce43-11e4-9416-80a806ccd697.png)
