### PR TITLE
Export all webhook information as environment variables during a build.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/deploydb/DeployDbBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/deploydb/DeployDbBuildAction.java
@@ -1,0 +1,104 @@
+package org.jenkinsci.plugins.deploydb;
+
+import com.google.common.base.CaseFormat;
+import hudson.EnvVars;
+import hudson.model.AbstractBuild;
+import hudson.model.EnvironmentContributingAction;
+import org.jenkinsci.plugins.deploydb.model.TriggerWebhook;
+
+import java.util.Map;
+
+import static com.google.common.base.CaseFormat.LOWER_CAMEL;
+import static hudson.Util.fixNull;
+
+/** Contains the data required for a DeployDB-triggered build, and exports it to the build environment. */
+public class DeployDbBuildAction implements EnvironmentContributingAction {
+
+    /** Prefix to apply to all environment variables this action exports. */
+    static final String ENV_VAR_PREFIX = "DDB_";
+
+    private final TriggerWebhook hook;
+
+    public DeployDbBuildAction(TriggerWebhook hook) {
+        this.hook = hook;
+    }
+
+    /** @return The webhook that triggered the build to which this action is attached. */
+    public TriggerWebhook getHook() {
+        return hook;
+    }
+
+    @Override
+    public void buildEnvVars(AbstractBuild<?, ?> build, EnvVars env) {
+        // Export the common environment variables
+        env.put(getEnvKey("eventId"), String.valueOf(hook.getId()));
+        env.put(getEnvKey("service"), hook.getService());
+
+        // Recursively export all other key/value pairs in the hook payload
+        exportHookValues(env, hook.getOtherValues());
+    }
+
+    private static void exportHookValues(EnvVars env, Map<String, Object> values) {
+        exportHookValues(env, null, values);
+    }
+
+    /**
+     * Recursively adds all key/values from the given map to the environment.
+     *
+     * @param env Environment to add to.
+     * @param nestingPrefix Optional prefix to add to each key, if the values map contains a nested map.
+     * @param values Key/value pairs to be added to the environment.
+     */
+    private static void exportHookValues(EnvVars env, String nestingPrefix, Map<String, Object> values) {
+        if (env == null || values == null) {
+            return;
+        }
+
+        nestingPrefix = fixNull(nestingPrefix).trim();
+        for (Map.Entry<String, Object> entry : values.entrySet()) {
+            Object value = entry.getValue();
+            if (value instanceof Map) {
+                exportHookValues(env, nestingPrefix + entry.getKey() + "_", (Map<String, Object>) value);
+            } else {
+                env.put(getEnvKey(entry.getKey(), nestingPrefix), String.valueOf(value));
+            }
+        }
+    }
+
+    private static String getEnvKey(String key) {
+        return getEnvKey(key, null);
+    }
+
+    /**
+     * Turns a key and optional prefix into a DeployDB environment variable name.
+     * <p/>
+     * Values in {@code camelCase} will be converted to be {@code UNDERSCORE_SEPARATED}.
+     *
+     * @param key Value, possibly camel-cased.
+     * @param nestingPrefix Optional string prefix, possibly camel-cased, e.g. {@code artifact} or {@code artifactInfo}.
+     * @return A value prefixed with {@link #ENV_VAR_PREFIX}, e.g. given the parameters {@code key=buildId} and
+     *         {@code nestingPrefix=artifact}, {@code DDB_ARTIFACT_BUILD_ID} would be returned.
+     */
+    private static String getEnvKey(String key, String nestingPrefix) {
+        nestingPrefix = fixNull(nestingPrefix).trim();
+        return ENV_VAR_PREFIX + LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, nestingPrefix + key);
+    }
+
+    // Not needed; this is not a UI-facing Action
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/deploydb/TriggerEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/deploydb/TriggerEndpoint.java
@@ -52,8 +52,7 @@ public class TriggerEndpoint implements UnprotectedRootAction {
 
         // Schedule a build for each of the jobs that matched
         for (AbstractProject<?, ?> job : jobs) {
-            // TODO: Build action
-            job.scheduleBuild2(0, new DeployDbCause());
+            job.scheduleBuild2(0, new DeployDbCause(), new DeployDbBuildAction(hook));
         }
 
         // Respond with success in all cases

--- a/src/main/java/org/jenkinsci/plugins/deploydb/model/TriggerWebhook.java
+++ b/src/main/java/org/jenkinsci/plugins/deploydb/model/TriggerWebhook.java
@@ -1,14 +1,21 @@
 package org.jenkinsci.plugins.deploydb.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /** Represents a webhook sent from DeployDB in order to trigger Jenkins builds. */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class TriggerWebhook {
 
     // TODO: Type of hook
     private long id;
     private String service;
+    private Map<String, Object> map;
+
+    private TriggerWebhook() {
+        this.map = new HashMap<String, Object>();
+    }
 
     public long getId() {
         return id;
@@ -18,9 +25,20 @@ public class TriggerWebhook {
         return service;
     }
 
+    /** Allows Jackson to set hook key/values we're not explicitly interested in. */
+    @JsonAnySetter
+    public void setOtherValue(String name, Object value) {
+        map.put(name, value);
+    }
+
+    /** @return A map of the payload fields we're not explicitly interested in. */
+    public Map<String, Object> getOtherValues() {
+        return map;
+    }
+
     @Override
     public String toString() {
-        return String.format("Webhook{id=%s, service=%s}", id, service);
+        return String.format("Webhook{id=%s, service=%s, values=%s}", id, service, map);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/deploydb/DeployDbBuildActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/deploydb/DeployDbBuildActionTest.java
@@ -1,0 +1,76 @@
+package org.jenkinsci.plugins.deploydb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hudson.EnvVars;
+import org.jenkinsci.plugins.deploydb.model.TriggerWebhook;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class DeployDbBuildActionTest {
+
+    @Test public void jsonPropertiesShouldBeExportedToEnvironment() throws Exception {
+        // Given a build action has been created from a JSON webhook payload
+        TriggerWebhook hook = getWebhook("hook_trigger_deployment_started.json");
+        DeployDbBuildAction action = new DeployDbBuildAction(hook);
+
+        // When we generate the environment variables
+        final EnvVars env = new EnvVars();
+        action.buildEnvVars(null, env);
+
+        // Then the environment should contain the only the hook-provided values
+        assertThat(env.size(), is(11));
+
+        // And the basic properties we care about should exist in the environment
+        assertThat(env.get("DDB_EVENT_ID"), is("1"));
+        assertThat(env.get("DDB_SERVICE"), is("faas"));
+
+        // And other top-level items should have been added
+        assertThat(env.get("DDB_STATUS"), is("STARTED"));
+        assertThat(env.get("DDB_ENVIRONMENT"), is("pre-prod"));
+        assertThat(env.get("DDB_CREATED_AT"), is("2015-03-14T09:26:53+00:00"));
+
+        // And nested objects from the JSON should also have been added, each with the object's key as prefix
+        assertThat(env.get("DDB_ARTIFACT_ID"), is("2"));
+        assertThat(env.get("DDB_ARTIFACT_GROUP"), is("com.example.cucumber"));
+        assertThat(env.get("DDB_ARTIFACT_NAME"), is("cucumber-artifact"));
+        assertThat(env.get("DDB_ARTIFACT_VERSION"), is("1.0.1"));
+        assertEquals(
+                "http://example.com/maven/com.example.cucumber/cucumber-artifact/1.0.1/cucumber-artifact-1.0.1.jar",
+                env.get("DDB_ARTIFACT_SOURCE_URL"));
+        assertThat(env.get("DDB_ARTIFACT_CREATED_AT"), is("2015-03-14T09:26:53+00:00"));
+    }
+
+    @Test public void arbitraryNestedValuesShouldBeExportedToEnvironment() throws Exception {
+        // Given a build action has been created from a JSON webhook payload
+        TriggerWebhook hook = getWebhook("hook_trigger_nested.json");
+        DeployDbBuildAction action = new DeployDbBuildAction(hook);
+
+        // When we generate the environment variables
+        final EnvVars env = new EnvVars();
+        action.buildEnvVars(null, env);
+
+        // Then the environment should contain the only the hook-provided values
+        assertThat(env.size(), is(6));
+
+        // And arbitrary levels of nesting should work
+        assertThat(env.get("DDB_EVENT_ID"), is("1"));
+        assertThat(env.get("DDB_SERVICE"), is("faas"));
+        assertThat(env.get("DDB_FOO_BAR_ID"), is("2"));
+
+        // And maps whose keys are camel-cased should appear as underscore-separated values
+        assertThat(env.get("DDB_FOO_BAR_CHILD_NESTED_ITEM_PARENT_ID"), is("2"));
+        assertThat(env.get("DDB_FOO_BAR_CHILD_NESTED_ITEM_NESTED"), is("very"));
+        assertThat(env.get("DDB_FOO_BAR_CHILD_NESTED_ITEM_LEAF"), is("true"));
+    }
+
+    /** @return A request webhook object built from the contents of the given file. */
+    private TriggerWebhook getWebhook(String filename) throws IOException {
+        return new ObjectMapper().readValue(getClass().getResourceAsStream(filename), TriggerWebhook.class);
+    }
+
+}

--- a/src/test/resources/org/jenkinsci/plugins/deploydb/hook_trigger_deployment_started.json
+++ b/src/test/resources/org/jenkinsci/plugins/deploydb/hook_trigger_deployment_started.json
@@ -6,10 +6,10 @@
     "name" : "cucumber-artifact",
     "version" : "1.0.1",
     "sourceUrl" : "http://example.com/maven/com.example.cucumber/cucumber-artifact/1.0.1/cucumber-artifact-1.0.1.jar",
-    "createdAt" : "{{created_timestamp}}"
+    "createdAt" : "2015-03-14T09:26:53+00:00"
   },
   "status" : "STARTED",
   "service" : "faas",
   "environment" : "pre-prod",
-  "createdAt" : "{{created_timestamp}}"
+  "createdAt" : "2015-03-14T09:26:53+00:00"
 }

--- a/src/test/resources/org/jenkinsci/plugins/deploydb/hook_trigger_nested.json
+++ b/src/test/resources/org/jenkinsci/plugins/deploydb/hook_trigger_nested.json
@@ -1,0 +1,14 @@
+{
+  "id" : 1,
+  "service" : "faas",
+  "fooBar" : {
+    "id" : 2,
+    "child" : {
+      "nestedItem" : {
+         "parentId" : 2,
+         "nested" : "very",
+         "leaf" : true
+       }
+    }
+  }
+}


### PR DESCRIPTION
This includes support for arbitrarily-named key/value pairs, and multiple levels of nesting within the JSON webhook payload.

e.g. A key `json['artifact']['createdAt']` would be exported to the environment with the name `DDB_ARTIFACT_CREATED_AT`.

Closes #4.