### PR TITLE
Add ability to configure DeployDB base URL in the Jenkins system config.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/deploydb/DeployDbConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/deploydb/DeployDbConfig.java
@@ -1,0 +1,32 @@
+package org.jenkinsci.plugins.deploydb;
+
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
+
+@Extension
+public class DeployDbConfig extends GlobalConfiguration {
+
+    private String baseUrl;
+
+    public DeployDbConfig() {
+        load();
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        req.bindJSON(this, json);
+        save();
+        return true;
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/deploydb/DeployDbConfig/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/deploydb/DeployDbConfig/config.groovy
@@ -1,0 +1,11 @@
+package org.jenkinsci.plugins.deploydb.DeployDbConfig;
+
+f = namespace(lib.FormTagLib)
+
+f.section(title:_("DeployDB")) {
+
+    f.entry(field: 'baseUrl', title:_("Base URL"), description:_("Enter the base URL of a DeployDB installation")) {
+        f.textbox()
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/deploydb/DeployDbConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/deploydb/DeployDbConfigTest.java
@@ -1,0 +1,50 @@
+package org.jenkinsci.plugins.deploydb;
+
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlInput;
+import jenkins.model.GlobalConfiguration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class DeployDbConfigTest {
+
+    @Rule public final JenkinsRule jenkins = new JenkinsRule();
+
+    @Test public void submittingGlobalConfigSetsUrl() throws Exception {
+        final String baseUrl = "https://ddb.example.com:8443/deploydb";
+
+        // Given that no base URL has been configured
+        DeployDbConfig ddbConfig = GlobalConfiguration.all().get(DeployDbConfig.class);
+        assertThat(ddbConfig.getBaseUrl(), is(nullValue()));
+
+        // When the Jenkins global config page is submitted with a URL
+        HtmlForm form = jenkins.createWebClient().goTo("configure").getFormByName("config");
+        HtmlInput field = form.getInputByName("_.baseUrl");
+        field.setValueAttribute(baseUrl);
+        jenkins.submit(form);
+
+        // Then the correct URL should have been set and persisted
+        assertThat(ddbConfig.getBaseUrl(), is(baseUrl));
+    }
+
+    @Test public void loadingGlobalConfigShowsPersistedUrl() throws Exception {
+        final String baseUrl = "http://example.com/";
+
+        // Given that a base URL has been configured
+        DeployDbConfig ddbConfig = GlobalConfiguration.all().get(DeployDbConfig.class);
+        ddbConfig.setBaseUrl(baseUrl);
+
+        // When the Jenkins global config page is loaded
+        HtmlForm form = jenkins.createWebClient().goTo("configure").getFormByName("config");
+
+        // Then the config field should display the correct URL
+        HtmlInput field = form.getInputByName("_.baseUrl");
+        assertThat(field.getValueAttribute(), is(baseUrl));
+    }
+
+}


### PR DESCRIPTION
Required until DeployDB sends its own base URL information as part of its webhook requests.

Closes #5.