### PR TITLE
Add test to ensure that a newly-created job can be configured via the web UI

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/deploydb/JobConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/deploydb/JobConfigTest.java
@@ -1,0 +1,26 @@
+package org.jenkinsci.plugins.deploydb;
+
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.model.AbstractProject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertNotNull;
+
+public class JobConfigTest {
+
+    @Rule public final JenkinsRule jenkins = new JenkinsRule();
+
+    @Test public void newJobConfigurationShouldNotFail() throws Exception {
+        // Given we create a brand new job
+        AbstractProject<?, ?> job = jenkins.createFreeStyleProject();
+
+        // When we open its configuration page
+        HtmlPage page = jenkins.createWebClient().getPage(job, "configure");
+
+        // Then nothing untoward should happen (i.e. no 500 error)
+        assertNotNull(page);
+    }
+
+}


### PR DESCRIPTION
Without the fix from 0791f82, this test does not pass.